### PR TITLE
Fix 'lot' and 'lof' missing commands

### DIFF
--- a/lib/executor.ex
+++ b/lib/executor.ex
@@ -10,10 +10,14 @@ defmodule Executor do
     output = List.to_string(config['output'] || 'out.pdf')
     full_command = "cd #{local}/#{source} && #{command} && mv #{output} #{local}"
 
-    Logger.info "Command:"
-    Logger.info full_command
+    Logger.info "Command: " <> full_command
 
     System.put_env("PATH", System.get_env("PATH") <> ":/root/.cabal/bin")
-    :os.cmd String.to_charlist(full_command)
+    
+    full_command
+    |> String.to_charlist
+    |> :os.cmd
+    |> List.to_string
+    |> Logger.info
   end
 end

--- a/lib/pandoc.ex
+++ b/lib/pandoc.ex
@@ -23,8 +23,6 @@ defmodule Pandoc do
   defp configure_flags do
     %{
       toc: %{token: "--toc", func: &make_flag/2},
-      lof: %{token: "--lof", func: &make_flag/2},
-      lot: %{token: "--lot", func: &make_flag/2},
       filters: %{token: "--filter", func: &make_some_flags/2},
       output: %{token: ["-o", "out.pdf"], func: &make_flag/2},
       template_path: %{token: ["--template", nil], func: &make_flag/2},

--- a/test.yml
+++ b/test.yml
@@ -7,9 +7,9 @@ pandoc:
   template_path: "templates/test.latex"
   source_path:   "test/"
   output:        "test.pdf"
-  tof:           true
+  lof:           true
+  lot:           true
   toc:           true
-  tot:           true
   filters:
     - pandoc-crossref
     - pandoc-citeproc


### PR DESCRIPTION
Hot fixes:

* 'lot' and 'lof' are not supported by pandoc 2.0.6. We need wait for pandoc-crossref upgrading.
* add :os.cmd exiting logs
